### PR TITLE
[GM-138] DB 정의 (Redis) 테스트 코드 추가 only

### DIFF
--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
@@ -10,4 +10,6 @@ public interface ManagementService {
 
     ChatRoom findByRoomId(String _roomId);
 
+    void deleteByRoomId(String _roomId);
+
 }

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImpl.java
@@ -5,12 +5,10 @@ import com.gaaji.chat.statusmanagement.domain.entity.RoomId;
 import com.gaaji.chat.statusmanagement.domain.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ManagementServiceImpl implements ManagementService{
 
@@ -28,6 +26,13 @@ public class ManagementServiceImpl implements ManagementService{
         RoomId roomId = RoomId.of(_roomId);
 
         return chatRoomRepository.findById(roomId).orElseThrow();
+    }
+
+    @Override
+    public void deleteByRoomId(String _roomId) {
+        RoomId roomId = RoomId.of(_roomId);
+
+        chatRoomRepository.deleteById(roomId);
     }
 
 }

--- a/src/test/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImplTest.java
+++ b/src/test/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImplTest.java
@@ -1,7 +1,13 @@
 package com.gaaji.chat.statusmanagement.domain.service;
 
+import com.gaaji.chat.statusmanagement.domain.entity.ChatRoom;
+import com.gaaji.chat.statusmanagement.domain.entity.MemberId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
 
 @SpringBootTest
 class ManagementServiceImplTest {
@@ -9,8 +15,22 @@ class ManagementServiceImplTest {
     @Autowired
     ManagementService managementService;
 
-//    @Test
-    void 채팅방_저장_구독정보_변경() {
+    @Test
+    void 채팅방_저장() {
+        // given
+        ChatRoom testRoom = ChatRoom.create("room_1", List.of("member_1", "member_2"));
+
+        // when
+        managementService.saveNewChatRoom("room_1", List.of("member_1", "member_2"));
+
+        // then
+        ChatRoom findRoom = managementService.findByRoomId("room_1");
+        Assertions.assertEquals(testRoom.getRoomId(), findRoom.getRoomId());
+        Assertions.assertEquals(testRoom.getMembers().size(), findRoom.getMembers().size());
+        Assertions.assertFalse(findRoom.getMembers().get(MemberId.of("member_1")).getIsSubscribe());
+
+        // rollback
+        managementService.deleteByRoomId(findRoom.getRoomId().getId());
     }
 
 }


### PR DESCRIPTION
# GM-138 DB 정의 (Redis) 테스트 코드 추가 only
## Description
> GM-138 이슈는 종료되었지만 (관련 PR: https://github.com/gaaji/chat-status-management/pull/2), 추가한 테스트 코드가 제외되어 있어, 이를 추가하기 위한 PR.
