### PR TITLE
[GM-139] Kafka 및 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.h2database:h2'
 
-    // lombok
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    implementation 'org.testcontainers:kafka:1.17.6'
+
+    // util
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,35 @@
 version: "3"
 
 services:
+  # 서비스 명
+  mongodb:
+    # 사용할 이미지
+    image: mongo
+    # 컨테이너 실행 시 재시작
+    restart: always
+    # 컨테이너 이름 설정
+    container_name: mongo-gaaji
+    # 접근 포트 설정 (컨테이너 외부:컨테이너 내부)
+    ports:
+      - "27017:27017"
+    volumes:
+      # -v 옵션 (다렉토리 마운트 설정)
+      - ~/data/mongo/gaaji-market/chats:/data/db
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper-gaaji
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.12-2.5.0
+    container_name: kafka-gaaji
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - ~/data/kafka/gaaji-market:/var/run/docker.sock
   redis:
     image: redis
     restart: always

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/ChattedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/ChattedDto.java
@@ -1,0 +1,21 @@
+package com.gaaji.chat.statusmanagement.domain.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChattedDto {
+    private String roomId;
+    private String senderId;
+    private List<String> receiverIds;
+    private String content;
+
+    public static ChattedDto of(String roomId, String senderId, List<String> receiverIds, String content) {
+        return new ChattedDto(roomId, senderId, receiverIds, content);
+    }
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/ManagementController.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/ManagementController.java
@@ -1,0 +1,59 @@
+package com.gaaji.chat.statusmanagement.domain.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.chat.statusmanagement.domain.controller.dto.*;
+import com.gaaji.chat.statusmanagement.domain.service.ManagementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ManagementController {
+
+    private final ManagementService managementService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "chat-chatRoomCreated")
+    public void createNewChatRoom(String body) throws JsonProcessingException {
+        ChatRoomCreatedDto chatRoomCreatedDto = objectMapper.readValue(body, ChatRoomCreatedDto.class);
+
+        managementService.saveNewChatRoom(chatRoomCreatedDto.getRoomId(), chatRoomCreatedDto.getMemberIds());
+    }
+
+    @KafkaListener(topics = "chat-chatRoomDeleted")
+    public void deleteChatRoom(String body) throws JsonProcessingException {
+        ChatRoomDeletedDto chatRoomDeletedDto = objectMapper.readValue(body, ChatRoomDeletedDto.class);
+
+        managementService.deleteByRoomId(chatRoomDeletedDto.getRoomId());
+    }
+
+    @KafkaListener(topics = "chat-memberAdded")
+    public void addMember(String body) throws JsonProcessingException {
+        MemberAddedDto memberAddedDto = objectMapper.readValue(body, MemberAddedDto.class);
+
+        managementService.addMemberToChatRoom(memberAddedDto.getChatRoomId(), memberAddedDto.getMemberId());
+    }
+
+    @KafkaListener(topics = "chat-memberLeft")
+    public void removeMember(String body) throws JsonProcessingException {
+        MemberLeftDto memberLeftDto = objectMapper.readValue(body, MemberLeftDto.class);
+
+        managementService.removeMemberFromChatRoom(memberLeftDto.getChatRoomId(), memberLeftDto.getMemberId());
+    }
+
+    @KafkaListener(topics = "chat-memberSubscribed")
+    public void subscribe(String body) throws JsonProcessingException {
+        MemberSubscribedDto memberSubscribedDto = objectMapper.readValue(body, MemberSubscribedDto.class);
+
+        managementService.subscribe(memberSubscribedDto.getRoomId(), memberSubscribedDto.getMemberId());
+    }
+
+    @KafkaListener(topics = "chat-memberUnsubscribed")
+    public void unsubscribe(String body) throws JsonProcessingException {
+        MemberUnsubscribedDto memberUnsubscribedDto = objectMapper.readValue(body, MemberUnsubscribedDto.class);
+
+        managementService.unsubscribe(memberUnsubscribedDto.getRoomId(), memberUnsubscribedDto.getMemberId());
+    }
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationController.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationController.java
@@ -1,0 +1,23 @@
+package com.gaaji.chat.statusmanagement.domain.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.chat.statusmanagement.domain.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "chat-chatted")
+    public void sendMessageNotification(String body) throws JsonProcessingException {
+        ChattedDto chattedDto = objectMapper.readValue(body, ChattedDto.class);
+
+        notificationService.sendMessageNotification(chattedDto.getRoomId(), chattedDto.getSenderId(), chattedDto.getContent());
+    }
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationController.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.gaaji.chat.statusmanagement.domain.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChattedDto;
 import com.gaaji.chat.statusmanagement.domain.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChatRoomCreatedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChatRoomCreatedDto.java
@@ -1,0 +1,15 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomCreatedDto {
+    private String roomId;
+    private List<String> memberIds;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChatRoomDeletedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChatRoomDeletedDto.java
@@ -1,0 +1,12 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomDeletedDto {
+    private String roomId;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChattedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/ChattedDto.java
@@ -1,4 +1,4 @@
-package com.gaaji.chat.statusmanagement.domain.controller;
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberAddedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberAddedDto.java
@@ -1,0 +1,13 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberAddedDto {
+    private String chatRoomId;
+    private String memberId;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberLeftDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberLeftDto.java
@@ -1,0 +1,13 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLeftDto {
+    private String chatRoomId;
+    private String memberId;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberSubscribedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberSubscribedDto.java
@@ -1,0 +1,13 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSubscribedDto {
+    private String roomId;
+    private String memberId;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberUnsubscribedDto.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/controller/dto/MemberUnsubscribedDto.java
@@ -1,0 +1,13 @@
+package com.gaaji.chat.statusmanagement.domain.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberUnsubscribedDto {
+    private String roomId;
+    private String memberId;
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/entity/ChatRoom.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/entity/ChatRoom.java
@@ -52,11 +52,11 @@ public class ChatRoom implements Serializable {
         return this;
     }
 
-    public List<MemberId> getMemberIdsByUnsubscribe(String senderId) {
+    public List<String> getMemberIdsByUnsubscribe(String senderId) {
         return members.entrySet().stream()
                 .filter(e -> !e.getValue().getIsSubscribe())
                 .filter(e -> !Objects.equals(e.getKey().getId(), senderId))
-                .map(Map.Entry::getKey)
+                .map(e -> e.getKey().getId())
                 .collect(Collectors.toList());
     }
     

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaService.java
@@ -1,7 +1,7 @@
 package com.gaaji.chat.statusmanagement.domain.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.gaaji.chat.statusmanagement.domain.controller.ChattedDto;
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChattedDto;
 
 public interface KafkaService {
 

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaService.java
@@ -1,0 +1,10 @@
+package com.gaaji.chat.statusmanagement.domain.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.gaaji.chat.statusmanagement.domain.controller.ChattedDto;
+
+public interface KafkaService {
+
+    void sendMessageNotification(ChattedDto chattedDto) throws JsonProcessingException;
+
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaServiceImpl.java
@@ -1,0 +1,27 @@
+package com.gaaji.chat.statusmanagement.domain.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.chat.statusmanagement.domain.controller.ChattedDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaServiceImpl implements KafkaService{
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String TOPIC_SEND_MESSAGE = "chat-chatNotified";
+
+    @Override
+    public void sendMessageNotification(ChattedDto chattedDto) throws JsonProcessingException {
+        String message = objectMapper.writeValueAsString(chattedDto);
+
+        log.info("send kafka message - topic: {}, message: {}", TOPIC_SEND_MESSAGE, message);
+        kafkaTemplate.send(TOPIC_SEND_MESSAGE, message);
+    }
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/KafkaServiceImpl.java
@@ -2,7 +2,7 @@ package com.gaaji.chat.statusmanagement.domain.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gaaji.chat.statusmanagement.domain.controller.ChattedDto;
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChattedDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
@@ -31,6 +31,13 @@ public interface ManagementService {
     void deleteByRoomId(String _roomId);
 
     /**
+     * 채팅방을 삭제하는 메소드.
+     *
+     * @param chatRoom 채팅방
+     */
+    void deleteChatRoom(ChatRoom chatRoom);
+
+    /**
      * 특정 채팅방의 특정 유저의 웹소켓 구독 상태를
      * 구독으로 변경하는 메소드.
      *

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementServiceImpl.java
@@ -27,8 +27,15 @@ public class ManagementServiceImpl implements ManagementService{
     }
 
     @Override
-    public void deleteByRoomId(String _roomId) {
-        chatRoomRepository.deleteById(RoomId.of(_roomId));
+    public void deleteByRoomId(String roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(RoomId.of(roomId)).orElseThrow();
+
+        deleteChatRoom(chatRoom);
+    }
+
+    @Override
+    public void deleteChatRoom(ChatRoom chatRoom) {
+        chatRoomRepository.delete(chatRoom);
     }
 
     @Override

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/NotificationService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/NotificationService.java
@@ -1,7 +1,9 @@
 package com.gaaji.chat.statusmanagement.domain.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 public interface NotificationService {
 
-    void sendMessageNotification(String roomId, String senderId, String content);
+    void sendMessageNotification(String roomId, String senderId, String content) throws JsonProcessingException;
 
 }

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/NotificationServiceImpl.java
@@ -1,7 +1,7 @@
 package com.gaaji.chat.statusmanagement.domain.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.gaaji.chat.statusmanagement.domain.controller.ChattedDto;
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChattedDto;
 import com.gaaji.chat.statusmanagement.domain.entity.ChatRoom;
 import com.gaaji.chat.statusmanagement.domain.entity.RoomId;
 import com.gaaji.chat.statusmanagement.domain.repository.ChatRoomRepository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,22 +1,30 @@
 spring:
+  application:
+    name: chat-status-management
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: gaaji-chat
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      client-id: chat-status-management
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
   datasource:
     url: jdbc:h2:mem:test;MODE=mysql;
     driverClassName: org.h2.Driver
     username: sa
     password:
+
   h2:
     console:
       enabled: true
       path: /h2-console
-  sql:
-    init:
-      encoding: utf-8
+
   redis:
     host: localhost
     port: 6379
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        format_sql: true

--- a/src/test/java/com/gaaji/chat/statusmanagement/domain/controller/ManagementControllerTest.java
+++ b/src/test/java/com/gaaji/chat/statusmanagement/domain/controller/ManagementControllerTest.java
@@ -1,0 +1,112 @@
+package com.gaaji.chat.statusmanagement.domain.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.gaaji.chat.statusmanagement.domain.entity.ChatRoom;
+import com.gaaji.chat.statusmanagement.domain.entity.MemberId;
+import com.gaaji.chat.statusmanagement.domain.entity.Subscribe;
+import com.gaaji.chat.statusmanagement.domain.service.ManagementServiceImpl;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class ManagementControllerTest {
+
+    @Autowired
+    private ManagementController controller;
+
+    @Autowired
+    private ManagementServiceImpl service;
+
+    @Nested
+    @DisplayName("Management 컨트롤러 정상 시나리오 테스트")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class 정상_시나리오 {
+
+        @Test
+        @Order(1)
+        @DisplayName("채팅방 생성 테스트")
+        void createNewChatRoomTest() throws JsonProcessingException {
+            String body = "{\"roomId\":\"room_1\", \"memberIds\": [ \"member_1\",\"member_2\"] }";
+            controller.createNewChatRoom(body);
+
+            ChatRoom chatRoom = service.findByRoomId("room_1");
+            Assertions.assertNotNull(chatRoom);
+            Assertions.assertEquals("room_1", chatRoom.getRoomId().getId());
+            Assertions.assertEquals(2, chatRoom.getMembers().size());
+        }
+
+        @Test
+        @Order(2)
+        @DisplayName("채팅방 삭제 테스트")
+        void deleteChatRoomTest() throws JsonProcessingException {
+            service.saveNewChatRoom("room_2", List.of("member_1"));
+
+            String body = "{ \"roomId\": \"room_2\" }";
+
+            controller.deleteChatRoom(body);
+        }
+
+        @Test
+        @Order(3)
+        @DisplayName("채팅방 입장 테스트")
+        void addMemberTest() throws JsonProcessingException {
+            String body = "{ \"chatRoomId\": \"room_1\", \"memberId\": \"member_3\" }";
+            controller.addMember(body);
+
+            ChatRoom chatRoom = service.findByRoomId("room_1");
+            Assertions.assertNotNull(chatRoom);
+            Assertions.assertEquals(3, chatRoom.getMembers().size());
+            Assertions.assertNotNull(chatRoom.getMembers().get(MemberId.of("member_3")));
+        }
+
+        @Test
+        @Order(4)
+        @DisplayName("채팅방 퇴장 테스트")
+        void removeMemberTest() throws JsonProcessingException {
+            String body = "{ \"chatRoomId\": \"room_1\", \"memberId\": \"member_3\" }";
+            controller.removeMember(body);
+
+            ChatRoom chatRoom = service.findByRoomId("room_1");
+            Assertions.assertNotNull(chatRoom);
+            Assertions.assertEquals(2, chatRoom.getMembers().size());
+            Assertions.assertNull(chatRoom.getMembers().get(MemberId.of("member_3")));
+        }
+
+        @Test
+        @Order(5)
+        @DisplayName("유저 구독 상태로 변경 테스트")
+        void subscribedChatRoom() throws JsonProcessingException {
+            String body = "{ \"roomId\" : \"room_1\", \"memberId\": \"member_1\" }";
+            controller.subscribe(body);
+
+            ChatRoom chatRoom = service.findByRoomId("room_1");
+            Assertions.assertNotNull(chatRoom);
+            Subscribe subscribe = chatRoom.getMembers().get(MemberId.of("member_1"));
+            Assertions.assertNotNull(subscribe);
+            Assertions.assertTrue(subscribe.getIsSubscribe());
+        }
+
+        @Test
+        @Order(6)
+        @DisplayName("유저 구독 해제 상태로 변경 테스트")
+        void unsubscribedChatRoom() throws JsonProcessingException {
+            String body = "{ \"roomId\" : \"room_1\", \"memberId\": \"member_1\" }";
+            controller.unsubscribe(body);
+
+            ChatRoom chatRoom = service.findByRoomId("room_1");
+            Assertions.assertNotNull(chatRoom);
+            Subscribe subscribe = chatRoom.getMembers().get(MemberId.of("member_1"));
+            Assertions.assertNotNull(subscribe);
+            Assertions.assertFalse(subscribe.getIsSubscribe());
+        }
+
+        @Test
+        @Order(999)
+        void rollback() {
+            service.deleteByRoomId("room_1");
+        }
+    }
+}

--- a/src/test/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationControllerTest.java
+++ b/src/test/java/com/gaaji/chat/statusmanagement/domain/controller/NotificationControllerTest.java
@@ -1,0 +1,47 @@
+package com.gaaji.chat.statusmanagement.domain.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class NotificationControllerTest {
+
+    @Autowired
+    private NotificationController notificationController;
+    @Autowired
+    private ManagementController managementController;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("Notification 컨트롤러 정상 시나리오 테스트")
+    class 정상_시나리오 {
+
+        @Test
+        @Order(1)
+        void init() throws JsonProcessingException {
+            String body = "{\"roomId\":\"room_1\", \"memberIds\": [ \"member_1\",\"member_2\",\"member_3\",\"member_4\",\"member_5\"] }";
+            managementController.createNewChatRoom(body);
+        }
+
+        @Test
+        @Order(2)
+        @DisplayName("채팅 메시지 전달 테스트")
+        void sendMessageNotification() throws JsonProcessingException {
+            String body = "{ \"roomId\": \"room_1\", \"senderId\": \"member_1\", \"content\": \"알림서버 전달 메시지 테스트.\" }";
+            notificationController.sendMessageNotification(body);
+        }
+
+        @Test
+        @Order(999)
+        void rollback() throws JsonProcessingException {
+            String body = "{\"roomId\":\"room_1\"}";
+            managementController.deleteChatRoom(body);
+        }
+
+    }
+
+}

--- a/src/test/java/com/gaaji/chat/statusmanagement/domain/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/gaaji/chat/statusmanagement/domain/service/NotificationServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.gaaji.chat.statusmanagement.domain.service;
 
 import com.gaaji.chat.statusmanagement.domain.entity.ChatRoom;
-import com.gaaji.chat.statusmanagement.domain.entity.MemberId;
 import com.gaaji.chat.statusmanagement.domain.entity.RoomId;
 import com.gaaji.chat.statusmanagement.domain.repository.ChatRoomRepository;
 import org.junit.jupiter.api.Assertions;
@@ -42,7 +41,7 @@ class NotificationServiceImplTest {
         chatRoom.updateMemberSubscribed("member_5");
 
         // member_3이 발신자
-        List<MemberId> notificationMemberIds = chatRoom.getMemberIdsByUnsubscribe("member_3");
+        List<String> notificationMemberIds = chatRoom.getMemberIdsByUnsubscribe("member_3");
         Assertions.assertNotNull(notificationMemberIds);
         Assertions.assertEquals(5, notificationMemberIds.size());
     }


### PR DESCRIPTION
# GM-139 Kafka 및 API 추가
## Description
> 채팅 상태관리 서버의 Kafka 이벤트 소비 및 발행 로직에 대한 API 추가한 PR.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [x] Refactor (code, package, etc.)
- [x] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [x] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-129 채팅 상태관리 서버 구현

## Issues
### DTO 생성
- `ChatRoomCreatedDto`
- `ChatRoomDeletedDto`
- `ChattedDto`
- `MemberAddedDto`
- `MemberLeftDto`
- `MemberSubscribedDto`
- `MemberUnsubscribedDto` 

### Controllers
> 상태관리 서버에서 Controller는 카프카 리스너를 통해 서버로 input 되는 데이터에 대하여 선처리하고 서비스로 전달해주기 위한 계층이다.   
Controller는 현재 두 가지가 있다. `ManagementController`, `NotificationController`이며, 이는 각각 채팅방 및 유저의 상태관리를 처리하고, 채팅 이벤트에 대하여 알림서버로 전달하는 로직을 처리한다.
  
> 모든 Controller의 메소드의 구조는 JSON으로 input되는 데이터를 각 DTO로 변환시킨 후, 각 서비스 단으로 전달하는 역할을 수행한다. 아래 코드는 ManagementController의 채팅방 생성을 처리하는 리스너다.

 ```java
// ManagementController

   @KafkaListener(topics = "chat-chatRoomCreated")
    public void createNewChatRoom(String body) throws JsonProcessingException {
        ChatRoomCreatedDto chatRoomCreatedDto = objectMapper.readValue(body, ChatRoomCreatedDto.class);

        managementService.saveNewChatRoom(chatRoomCreatedDto.getRoomId(), chatRoomCreatedDto.getMemberIds());
    }
```

### Kafka
> Kafka는 `KakfaService` 인터페이스를 통해 메시지를 발행한다. NotificiationService가 구독 해제 상태인 유저의 아이디 리스트와 함께 채팅 정보를 KafkaService에게 전달하면, KafkaService는 JSON으로 변환하여 메시지를 발행한다.

 ```java
// NotificationServiceImpl

   @Override
    public void sendMessageNotification(String roomId, String senderId, String content) throws JsonProcessingException {
        ChatRoom chatRoom = chatRoomRepository.findById(RoomId.of(roomId)).orElseThrow();

        List<String> notificationMemberIds = chatRoom.getMemberIdsByUnsubscribe(senderId);

        ChattedDto chattedDto = ChattedDto.of(roomId, senderId, notificationMemberIds, content);
        kafkaService.sendMessageNotification(chattedDto);
    }
```

```java
// KafkaServiceImpl

    @Override
    public void sendMessageNotification(ChattedDto chattedDto) throws JsonProcessingException {
        String message = objectMapper.writeValueAsString(chattedDto);

        log.info("send kafka message - topic: {}, message: {}", TOPIC_SEND_MESSAGE, message);
        kafkaTemplate.send(TOPIC_SEND_MESSAGE, message);
    }
```

## Test
### ManagementControllerTest
![image](https://user-images.githubusercontent.com/42243302/214788684-1c54f59e-a966-43b6-b734-7379df9dbf49.png)

### NotificationControllerTest
![image](https://user-images.githubusercontent.com/42243302/214788857-0f33c97a-a359-4f20-af7d-8caef1279a26.png)
![image](https://user-images.githubusercontent.com/42243302/214788904-747a0428-ef6e-4546-91a9-754268e57d60.png)

*** 

## Related Files
- `ManagementController`
- `NotificationController`
- `KafkaService` & `KafkaServiceImpl`

## Think About..  
- JsonProcessingException 관련 에러 핸들링 추가해야 함. -> GM-152
- ChattedDto 분리 고려. -> GM-155

## Conclusion  
> 메시지 서버를 하며 kafka를 다뤄본 적이 있어 빠르게 추가, 연동할 수 있었다. 아직 에러 핸들링에 대한 처리를 하지 않았음으로 다음 이슈 처리로 바로 에러 핸들링을 해야겠음.

