### PR TITLE
[GM-152] 예외상황 핸들링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,19 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2021.0.5")
+}
+
 dependencies {
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.h2database:h2'
 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.0.1'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
@@ -36,6 +43,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gaaji/chat/statusmanagement/ChatStatusManagementApplication.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/ChatStatusManagementApplication.java
@@ -2,7 +2,9 @@ package com.gaaji.chat.statusmanagement;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class ChatStatusManagementApplication {
 

--- a/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/domain/service/ManagementService.java
@@ -9,26 +9,26 @@ public interface ManagementService {
     /**
      * 새로운 채팅방을 저장하는 메소드.
      *
-     * @param _roomId 채팅방 ID
-     * @param _memberIds 유저 ID 리스트
+     * @param roomId 채팅방 ID
+     * @param memberIds 유저 ID 리스트
      * @return ChatRoom
      */
-    ChatRoom saveNewChatRoom(String _roomId, List<String> _memberIds);
+    ChatRoom saveNewChatRoom(String roomId, List<String> memberIds);
 
     /**
      * 채팅방 ID로 채팅방을 조회하는 메소드.
      *
-     * @param _roomId 채팅방 ID
+     * @param roomId 채팅방 ID
      * @return ChatRoom
      */
-    ChatRoom findByRoomId(String _roomId);
+    ChatRoom findByRoomId(String roomId);
 
     /**
      * 채팅방 ID로 채팅방을 삭제하는 메소드.
      *
-     * @param _roomId 채팅방 ID
+     * @param roomId 채팅방 ID
      */
-    void deleteByRoomId(String _roomId);
+    void deleteByRoomId(String roomId);
 
     /**
      * 채팅방을 삭제하는 메소드.
@@ -41,33 +41,33 @@ public interface ManagementService {
      * 특정 채팅방의 특정 유저의 웹소켓 구독 상태를
      * 구독으로 변경하는 메소드.
      *
-     * @param _roomId 채팅방 ID
-     * @param _memberId 유저 ID
+     * @param roomId 채팅방 ID
+     * @param memberId 유저 ID
      */
-    void subscribe(String _roomId, String _memberId);
+    void subscribe(String roomId, String memberId);
 
     /**
      * 특정 채팅방의 특정 유저의 웹소켓 구독 상태를
      * 구독 해제로 변경하는 메소드.
      *
-     * @param _roomId 채팅방 ID
-     * @param _memberId 유저 ID
+     * @param roomId 채팅방 ID
+     * @param memberId 유저 ID
      */
-    void unsubscribe(String _roomId, String _memberId);
+    void unsubscribe(String roomId, String memberId);
 
     /**
      * 특정 채팅방에 새로운 유저를 추가하는 메소드.
      *
-     * @param _roomId 채팅방 ID
-     * @param _memberId 유저 ID
+     * @param roomId 채팅방 ID
+     * @param memberId 유저 ID
      */
-    void addMemberToChatRoom(String _roomId, String _memberId);
+    void addMemberToChatRoom(String roomId, String memberId);
 
     /**
      * 특정 채팅방에 특정 유저를 삭제하는 메소드.
      *
-     * @param _roomId 채팅방 ID
-     * @param _memberId 유저 ID
+     * @param roomId 채팅방 ID
+     * @param memberId 유저 ID
      */
-    void removeMemberFromChatRoom(String _roomId, String _memberId);
+    void removeMemberFromChatRoom(String roomId, String memberId);
 }

--- a/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/RedisConfig.java
@@ -1,7 +1,7 @@
-package com.gaaji.chat.statusmanagement.global.config;
+package com.gaaji.chat.statusmanagement.global.config.redis;
 
-import com.gaaji.chat.statusmanagement.global.config.converter.MemberIdConversion;
-import com.gaaji.chat.statusmanagement.global.config.converter.RoomIdConversion;
+import com.gaaji.chat.statusmanagement.global.config.redis.converter.MemberIdConversion;
+import com.gaaji.chat.statusmanagement.global.config.redis.converter.RoomIdConversion;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Configuration
-//@EnableRedisRepositories
 public class RedisConfig {
 
     @Value("${spring.redis.host}")

--- a/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/converter/MemberIdConversion.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/converter/MemberIdConversion.java
@@ -1,4 +1,4 @@
-package com.gaaji.chat.statusmanagement.global.config.converter;
+package com.gaaji.chat.statusmanagement.global.config.redis.converter;
 
 import com.gaaji.chat.statusmanagement.domain.entity.MemberId;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/converter/RoomIdConversion.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/global/config/redis/converter/RoomIdConversion.java
@@ -1,4 +1,4 @@
-package com.gaaji.chat.statusmanagement.global.config.converter;
+package com.gaaji.chat.statusmanagement.global.config.redis.converter;
 
 import com.gaaji.chat.statusmanagement.domain.entity.RoomId;
 import org.springframework.core.convert.converter.Converter;

--- a/src/main/java/com/gaaji/chat/statusmanagement/global/errorhandler/ErrorHandler.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/global/errorhandler/ErrorHandler.java
@@ -1,0 +1,18 @@
+package com.gaaji.chat.statusmanagement.global.errorhandler;
+
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChatRoomCreatedDto;
+import com.gaaji.chat.statusmanagement.global.feign.ChatApiServiceClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ErrorHandler {
+
+    private final ChatApiServiceClient chatApiServiceClient;
+
+    public ChatRoomCreatedDto handleChatRoomIdNotFound(String roomId) {
+        return chatApiServiceClient.getChatRoom(roomId);
+    }
+
+}

--- a/src/main/java/com/gaaji/chat/statusmanagement/global/feign/ChatApiServiceClient.java
+++ b/src/main/java/com/gaaji/chat/statusmanagement/global/feign/ChatApiServiceClient.java
@@ -1,0 +1,14 @@
+package com.gaaji.chat.statusmanagement.global.feign;
+
+import com.gaaji.chat.statusmanagement.domain.controller.dto.ChatRoomCreatedDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient("chat-api")
+public interface ChatApiServiceClient {
+
+    @GetMapping("/error/chat-rooms/{chatRoomId}")
+    ChatRoomCreatedDto getChatRoom(@PathVariable("chatRoomId") String roomId);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,10 @@ spring:
   redis:
     host: localhost
     port: 6379
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    service-url:
+      defaultZone: http://localhost:8761/eureka


### PR DESCRIPTION
# [GM-152] 예외상황 핸들링
## Description
> 채팅 상태관리 서버에서 발생하는 예외 상황에 대한 핸들링을 처리하는 PR이다. Kafka 이벤트 요청에 대하여 자원의 조회 실패 시 API 서버에게 FeignClient로 요청하여 핸들링하도록 하였다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [x] Refactor (code, package, etc.)
- [x] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [x] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-129

## Issues
현재까지 처리하는 예외상황은 상태관리서버 DB에 요청되는 채팅방ID가 존재하지 않는 경우에 대한 핸들링이다.   
핸들링은 다음과 같이 처리된다. 
1. 채팅방 ID가 존재하지 않으면, API 서버에게 채팅방 ID를 제공하며 채팅방의 정보를 응답받는다.
2. 응답 받은 채팅방 정보를 DB에 저장한다.
3. 저장된 채팅방 정보를 반환함으로, 채팅방 ID가 존재하지 않아도 Exception이 발생되지 않게 된다.

### 의존성 추가
> OpenFeign을 통해 API 서버에게 http 요청을 하기 위해 spring cloud, eureka, openFeign, spring web의 의존성을 추가하여 라이브러리를 추가하였다.

 ```java
    implementation 'org.springframework.boot:spring-boot-starter-web'
    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.0.1'
    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
```

### FeignClient
> Application 클래스에 FeginClient를 사용한다는 어노테이션을 추가하였다.
```java
@EnableFeignClients
@SpringBootApplication
public class ChatStatusManagementApplication 
```

> `global.feign` 패키지에 `ChatApiServiceClient` 인터페이스를 추가하여 chat-api 서버에게 요청하도록 한다.
```java
@FeignClient("chat-api")
public interface ChatApiServiceClient {

    @GetMapping("/error/chat-rooms/{chatRoomId}")
    ChatRoomCreatedDto getChatRoom(@PathVariable("chatRoomId") String roomId);

}
```

### Error Handler
> FeignClient를 호출하는 에러 핸들링 구현체로 FeignClient의 응답을 반환하는 메소드를 정의하였다.
```java
@Component
@RequiredArgsConstructor
public class ErrorHandler {

    private final ChatApiServiceClient chatApiServiceClient;

    public ChatRoomCreatedDto handleChatRoomIdNotFound(String roomId) {
        return chatApiServiceClient.getChatRoom(roomId);
    }

}
```

### 채팅방 정보 조회
> `ManagementService`을 통해 채팅방 정보를 조회하는데, 만일 DB에 저장되어 있지 않다면, ErrorHandler의 상기 메소드를 호출하여 API 서버로부터 채팅방 정보를 받아온 다음, DB에 저장하고, 반환한다.  

> 모든 채팅방 정보를 조회해야 하는 로직에 대해서는 `ManagementService`의 `findByRoomId()`를 통해서만 이뤄지도록 하여, 모든 조회에 대하여 예외를 핸들링한다.

```java
// class ManagementServiceImpl

    @Override
    public ChatRoom findByRoomId(String roomId) {
        ChatRoom chatRoom;
        Optional<ChatRoom> chatRoomOptional = chatRoomRepository.findById(RoomId.of(roomId));
        if ( chatRoomOptional.isPresent() ) {
            chatRoom = chatRoomOptional.get();
        } else {
            ChatRoomCreatedDto chatRoomCreatedDto = errorHandler.handleChatRoomIdNotFound(roomId);
            chatRoom = saveNewChatRoom(chatRoomCreatedDto.getRoomId(), chatRoomCreatedDto.getMemberIds());
        }
        return chatRoom;
    }
```

## Test
> OpenFeign의 테스팅은 간단치 않기에, 추후 테스트해 볼 예정이다.  

*** 

## Related Files
- `ChatApiServiceClient`
- `ErrorHandler`
- `ManagementService` & `ManagementServiceImpl`

## Think About..  
- OpenFeign 응답이 에러일 경우에 대한 로직을 추가해야 함.
- 테스트

## Conclusion  
> 일주일 끝!
